### PR TITLE
Update generation of configmap name

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -16,8 +16,8 @@
 apiVersion: v2
 name: dnation-kubernetes-jsonnet-translator
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 description: dNation Translator is a simple container for translating jsonnet content stored in k8s configmaps to **grafana dashboards** or **prometheus rules**.
 keywords:
   - jsonnet

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install /app
 
 FROM python:3.8-slim
 
-LABEL Version="1.0.0"
+LABEL Version="1.0.1"
 LABEL Vendor="dNation"
 LABEL Description="Container generates json resources from jsonnet resources (grafana dashboards, prometheus rules)"
 

--- a/translator/main.py
+++ b/translator/main.py
@@ -412,8 +412,11 @@ def create_dashboard_cm(
 
         data = {}
         data[filename] = json.dumps(json_data)
-        # name = grafana-dashboards-generated-<filename-without-.json>
-        name = "-".join([args_.grafana_dashboards_cm_name, filename[:-5]])
+        # name = grafana-dashboards-generated-<filename-without-.json>,
+        # which is converted to valid DNS Subdomain Name
+        name = utils.convert_name_to_valid_dns_subdomain_name(
+            "-".join([args_.grafana_dashboards_cm_name, filename[:-5]])
+        )
 
         configmap = client.V1ConfigMap(
             data=data,

--- a/translator/utils.py
+++ b/translator/utils.py
@@ -21,6 +21,7 @@ import binascii
 import logger
 import shutil
 from datetime import datetime
+import re
 
 
 log = logger.get_logger()
@@ -171,3 +172,28 @@ def extract_archive_data(archive_data, archive_name, folder):
         log.error(f"Error when extracting {archive_name}, error: {e}")
 
     remove_file("./", archive_name)
+
+
+def convert_name_to_valid_dns_subdomain_name(name):
+    """Convert name to a valid DNS Subdomain Name as defined in RFC 1123
+       because most resource types in kubernetes require it.
+       https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+
+    Args:
+        name (str): name that need to be converted into valid format
+
+    Returns:
+        Name that can be used as a valid DNS subdomain name
+    """
+    name = re.sub(r'[^a-zA-Z0-9]+', '-', name).lower()
+    # name must contain no more than 253 characters
+    if len(name) > 253:
+        name = name[:253]
+    # name must start with an alphanumeric character
+    if name and name[0] == "-":
+        name = name[1:]
+    # name must end with an alphanumeric character
+    if name and name[-1] == "-":
+        name = name[:-1]
+
+    return name


### PR DESCRIPTION
Names of kubernetes resources require a name that can be used as a DNS subdomain name as defined in RFC 1123. https://kubernetes.io/docs/concepts/overview/working-with-objects/names/