### PR TITLE
Replace replace jsonnet with go-jsonnet

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -16,8 +16,8 @@
 apiVersion: v2
 name: dnation-kubernetes-jsonnet-translator
 type: application
-version: 1.0.1
-appVersion: 1.0.1
+version: 1.0.2
+appVersion: 1.0.2
 description: dNation Translator is a simple container for translating jsonnet content stored in k8s configmaps to **grafana dashboards** or **prometheus rules**.
 keywords:
   - jsonnet

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 
 FROM python:3.8 AS python-builder
 RUN apt-get update
-
+RUN apt-get install -y golang-go
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
@@ -15,7 +15,7 @@ RUN pip3 install /app
 
 FROM python:3.8-slim
 
-LABEL Version="1.0.1"
+LABEL Version="1.0.2"
 LABEL Vendor="dNation"
 LABEL Description="Container generates json resources from jsonnet resources (grafana dashboards, prometheus rules)"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,4 +28,4 @@ kubectl apply -f examples/prom-rule-jsonnet.yaml
 kubectl describe prometheusrule prometheus-rules-generated
 ```
 
-More examples can be found in [examples](examples) folder.
+More examples can be found in this folder.

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -18,6 +18,12 @@ Create kind cluster
 kind create cluster --config helpers/kind_cluster_config.yaml --image kindest/node:v1.20.2
 ```
 
+Create prometheus rule CRD
+- optional, if you do not create prometheus rule CRD you will see some 404 errors in translator logs
+```bash
+kubectl apply -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+```
+
 Translator can run without installation to cluster (but there has to be accessible cluster config).
 Install [jsonnet bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) and run:
 ```
@@ -34,7 +40,7 @@ Generate example grafana dashboard
 ```
 kubectl apply -f examples/grafana-jsonnet.yaml
 # see results
-kubectl desribe cm grafana-dashboards-generated-example-dashboard
+kubectl describe cm grafana-dashboards-generated-example-dashboard
 ```
 If everything was installed correctly, described config map should contain grafana dashboard in JSON.
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    "jsonnet==0.16.*",
+    "gojsonnet==0.17.*",
     "kubernetes==12.0.*",
     "patool==1.12",
     "urllib3==1.25.*",
@@ -31,7 +31,7 @@ setup(
     description="Generates json resources from jsonnet resources",
     author="dnation",
     author_email="david.suba@dnation.cloud",
-    version="0.3.0",
+    version="1.0.2",
     python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This patch incorporates a quick and dirty workaround for issue https://github.com/google/go-jsonnet/issues/484
As we want to replace jsonnet with go-jsonnet asap, because jsonnet is slow https://github.com/google/jsonnet/issues/672

Logging is why we do not use a "spawn" method for multiprocessing here. Unfortunately a nice multiprocessing logging solutions like [this](https://fanchenbao.medium.com/python3-logging-with-multiprocessing-f51f460b8778) only work for the "fork" start method.

Closes https://github.com/dNationCloud/kubernetes-jsonnet-translator/issues/30
